### PR TITLE
integrate with multicast menu api

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The code relies on the following third-party libraries:
 ## Usage
 The default configuration should suffice for most use cases, so simply do:
 ```
-$ python3 translator.py
+$ python3 translator.py --mm-uid SAMPLE_MM_UID
 Press enter to terminate the translator...
 read timeout: nothing to be translated this iteration
 read timeout: nothing to be translated this iteration
 ...
 Multicast address (232.74.37.48, 9002) allocated for ('66.129.239.15', 31380).
-Added amt://162.250.138.11@232.74.37.48:9002 to the Multicast Menu (email=lenny@juniper.net; description=Translated stream originating from 66.129.239.15).
+Added amt://162.250.138.11@232.74.37.48:9002 to the Multicast Menu (source=66.129.239.15). The access code is SAMPLE_ACCESS_CODE.
 ```
 Once the translator is running, you can terminate it by pressing enter. The translator will report a read timeout at
 periodic intervals (currently set to 5 seconds) as long as it is not receiving any unicast packets for translation.
@@ -84,7 +84,7 @@ new flow.
 This initial unicast packet, and any subsequent unicast packets pertaining to that same flow, will then be translated to
 multicast packets with a destination IP matching the multicast address that was reserved for the unicast flow.
 The translator will also add information about the new stream to the
-[Multicast Menu](https://multicastmenu.herokuapp.com).
+[Multicast Menu](https://menu.treedn.net).
 An example of what these entries will look like is provided in the screenshot below.
 
 ![Listing of a translated stream on the Multicast Menu](doc/img/multicast_menu.png)
@@ -100,6 +100,7 @@ usage: translator.py [-h] [--unicast-nif-ip UNICAST_NIF_IP]
                      [--unicast-port UNICAST_PORT]
                      [--multicast-addr-space MULTICAST_ADDR_SPACE]
                      [--multicast-port MULTICAST_PORT]
+                     [--mm_uid MULTICAST_MENU_UID]
 
 Start a unicast-to-multicast translation service on this machine.
 
@@ -125,6 +126,10 @@ optional arguments:
                         port number will be used for all translated flows.
                         Thus, a translated flow is identified solely by its
                         assigned multicast IP address (group). Default: 9002
+  --multicastmenu_uid MULTICAST_MENU_UID
+                        UID used to identify the translator to Multicast Menu
+                        when adding streams. If this is not set, the translator
+                        will not attempt to add streams to Multicast Menu.
 ```
 Note that the default value for `--unicast-nif-ip` is determined dynamically so `python3 translator.py --help` will 
 report a different default value for this option on your machine.

--- a/constants.py
+++ b/constants.py
@@ -8,10 +8,11 @@ DEFAULT_MULTICAST_ADDR_SPACE = ipaddress.IPv4Network('232.0.0.0/8')
 # Default port to use when forwarding payload received on the translator's unicast server socket as multicast.
 DEFAULT_MULTICAST_PORT = 9002
 # URL to use when submitting stream information to the Multicast Menu
-MULTICASTMENU_ADD_URL = 'https://multicastmenu.herokuapp.com/add/'
-# Email address to use when submitting stream information to the Multicast Menu. Lenny has OK'ed using his email address
-# until we have a group email.
-MULTICASTMENU_EMAIL = 'lenny@juniper.net'
+MULTICASTMENU_ADD_URL = 'https://menu.treedn.net/api/add/'
+# URL to use when removing stream information from the Multicast Menu
+MULTICASTMENU_REMOVE_URL = 'https://menu.treedn.net/api/remove/'
 # Number of worker threads dedicated to submitting stream information to the Multicast Menu.
 MULTICASTMENU_THREADS = 10
+# IPv4 address of Multicast Menu server used to identify streams that originate there.
+MULTICASTMENU_SENDER_IP = '54.234.212.72'
 # ======================================================================================================================

--- a/translator.py
+++ b/translator.py
@@ -274,7 +274,8 @@ class Translator:
                 "group": str(mcast_dst_ip),
             }
 
-            if str(src_ip) == constants.MULTICASTMENU_SENDER_IP:
+            if src_ip[0] == constants.MULTICASTMENU_SENDER_IP:
+                print("'Inside Request' set to True")
                 options["inside_request"] = "1"
 
             resp_post = requests.post(constants.MULTICASTMENU_ADD_URL, data=options)


### PR DESCRIPTION
Multicast Menu is now hosted at http://18.209.44.34 (DNS/SSL pending).

These changes are designed to replace the current method of adding streams to MM with the new API. The API also allows for the removal of streams, with the intent that the translator cleans up after itself. I've made these changes by adding two dictionaries, one to track activity and one to track the unique access code used to control each stream. A loop counter was also added to assist in tracking activity.

These changes will work as is, but a crucial step in full functionality is going to be allowing access to this server from the above IP address.

This relates to the concept of an "inside_request." This is very similar to a typical translation, except the sender is MM itself. This is intended to allow someone to upload a file to MM -> MM streams the file to the translation server -> TS makes an API call (with the "inside_request" parameter set) -> MM matches that API call to the file that it sent and updates s-g accordingly.

This will not work until MM can initiate that request to TS, i.e. it is whitelisted.

These changes are largely untested. On the MM side, the API calls will work (I dummy tested them). However, I don't know the best way to go about testing this without disrupting the current operation.

Thoughts?